### PR TITLE
Chore: Errors Flow Improvements

### DIFF
--- a/rpc-csharp-demo/rpc-csharp-demo.csproj
+++ b/rpc-csharp-demo/rpc-csharp-demo.csproj
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="UniTask" Version="2.3.1" />
+        <PackageReference Include="UniTask" Version="2.5.10" />
         <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
     </ItemGroup>
 

--- a/rpc-csharp-demo/rpc-csharp-demo.csproj
+++ b/rpc-csharp-demo/rpc-csharp-demo.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net48</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>9</LangVersion>
         <RootNamespace>rpc_csharp_demo</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>

--- a/rpc-csharp-demo/transport/WebSocketServerTransport.cs
+++ b/rpc-csharp-demo/transport/WebSocketServerTransport.cs
@@ -14,7 +14,7 @@ public class WebSocketServerTransport : WebSocketBehavior, ITransport
     protected override void OnError(ErrorEventArgs e)
     {
         base.OnError(e);
-        OnErrorEvent?.Invoke(e.Message);
+        OnErrorEvent?.Invoke(e.Exception);
     }
 
     protected override void OnClose(CloseEventArgs e)
@@ -48,7 +48,7 @@ public class WebSocketServerTransport : WebSocketBehavior, ITransport
     }
 
     public event Action OnCloseEvent;
-    public event Action<string> OnErrorEvent;
+    public event Action<Exception> OnErrorEvent;
     public event Action<byte[]> OnMessageEvent;
     public event Action OnConnectEvent;
 }

--- a/rpc-csharp-test/rpc-csharp-test.csproj
+++ b/rpc-csharp-test/rpc-csharp-test.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>9</LangVersion>
         <RootNamespace>rpc_csharp_test</RootNamespace>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>

--- a/rpc-csharp-test/rpc-csharp-test.csproj
+++ b/rpc-csharp-test/rpc-csharp-test.csproj
@@ -14,7 +14,7 @@
         <PackageReference Include="NUnit" Version="3.13.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="coverlet.collector" Version="3.1.0" />
-        <PackageReference Include="UniTask" Version="2.3.1" />
+        <PackageReference Include="UniTask" Version="2.5.10" />
     </ItemGroup>
 
     <ItemGroup>

--- a/rpc-csharp/rpc-csharp.csproj
+++ b/rpc-csharp/rpc-csharp.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.31.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.13.2" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
         <PackageReference Include="UniTask" Version="2.5.10" />
     </ItemGroup>

--- a/rpc-csharp/rpc-csharp.csproj
+++ b/rpc-csharp/rpc-csharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net48</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <LangVersion>9</LangVersion>
         <RootNamespace>rpc_csharp</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>

--- a/rpc-csharp/rpc-csharp.csproj
+++ b/rpc-csharp/rpc-csharp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net48</TargetFramework>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>9</LangVersion>
         <RootNamespace>rpc_csharp</RootNamespace>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.Protobuf" Version="3.12.3" />
+        <PackageReference Include="Google.Protobuf" Version="3.31.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.3" />
-        <PackageReference Include="UniTask" Version="2.3.1" />
+        <PackageReference Include="UniTask" Version="2.5.10" />
     </ItemGroup>
 
     <!--<Target Name="protogen" BeforeTargets="BeforeBuild">

--- a/rpc-csharp/rpc-csharp.csproj.DotSettings
+++ b/rpc-csharp/rpc-csharp.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=src_005Cruntime/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/rpc-csharp/src/Runtime/ClientRequestDispatcher.cs
+++ b/rpc-csharp/src/Runtime/ClientRequestDispatcher.cs
@@ -1,4 +1,5 @@
-using System.Threading;
+using System;
+using System.Collections.Concurrent;
 using Cysharp.Threading.Tasks;
 using Google.Protobuf;
 using rpc_csharp.protocol;
@@ -8,38 +9,144 @@ namespace rpc_csharp
 {
     public class ClientRequestDispatcher : MessageDispatcher
     {
-        public delegate void SendMessage();
-
+        // It doesn't feel right to preserve this number if the RPCClient has been recreated along with all its dependencies.
         private static uint globalMessageNumber = 0;
+        
+        private readonly ConcurrentDictionary<uint, UniTaskCompletionSource<ParsedMessage>> pendingMessages = new();
         
         public ClientRequestDispatcher(ITransport transport) : base(transport)
         {
         }
-
-        public UniTask<ParsedMessage> AwaitForMessage(uint messageNumber, SendMessage sendMessage = null)
+        
+        protected override void OnMessageParsed(ParsedMessage parsedMessage)
         {
-            return UniTask.Create(() =>
-            {
-                var responseFuture = new UniTaskCompletionSource<ParsedMessage>();
-
-                void OnMessage(ParsedMessage message)
-                {
-                    if (messageNumber != message.messageNumber) return;
-                    
-                    OnParsedMessage -= OnMessage;
-                    responseFuture.TrySetResult(message);
-                }
-
-                OnParsedMessage += OnMessage;
-
-                if (sendMessage != null)
-                    sendMessage();
-
-                return responseFuture.Task;
-            });
+            if (pendingMessages.TryRemove(parsedMessage.messageNumber, out var promise))
+                promise.TrySetResult(parsedMessage);
         }
 
-        public uint NextMessageNumber()
+        protected override void OnClose(Exception e)
+        {
+            // Reject regular messages
+            foreach (var promise in pendingMessages.Values)
+                promise.TrySetException(e);
+            
+            pendingMessages.Clear();
+        }
+
+        /// <summary>
+        /// Should be used only for messages that don't expect a response
+        /// </summary>
+        public void SendAndForget(IRpcMessage request, RpcMessageTypes messageType)
+        {
+            var requestMessageNumber = NextMessageNumber();
+
+            request.MessageIdentifier = ProtocolHelpers.CalculateMessageIdentifier(
+                messageType,
+                requestMessageNumber
+            );
+            
+            // TODO: find an opportunity to avoid such allocation
+            var payload = request.ToByteArray();
+            
+            transport.SendMessage(payload);
+        }
+
+        public UniTask<TResponse> SendAndWaitForResponse<TResponse>(IRpcMessage request, RpcMessageTypes messageType) where TResponse : class, IMessage
+        {
+            var requestMessageNumber = NextMessageNumber();
+
+            request.MessageIdentifier = ProtocolHelpers.CalculateMessageIdentifier(
+                messageType,
+                requestMessageNumber
+            );
+            
+            return SendAndWaitForResponse<TResponse>(request, requestMessageNumber);
+        }
+
+        public async UniTask<Response> HandleClientStream(Request negotiationMessage, uint portId, IUniTaskAsyncEnumerable<IMessage> stream)
+        {
+            var clientStreamMessageNumber = NextMessageNumber();
+            var requestMessageNumber = NextMessageNumber();
+
+            negotiationMessage.MessageIdentifier = ProtocolHelpers.CalculateMessageIdentifier(
+                RpcMessageTypes.Request,
+                requestMessageNumber
+            );
+            
+            negotiationMessage.ClientStream = clientStreamMessageNumber;
+            
+            
+            
+            // When the client stream has finished, Server will send the last element as an acknowledgment
+            var lastElementAck = new UniTaskCompletionSource<ParsedMessage>();
+            pendingMessages.TryAdd(requestMessageNumber, lastElementAck);
+            
+            await LaunchClientStreamAsync(negotiationMessage, portId, stream);
+            
+            // Wait for the last element or the error
+            var content = await lastElementAck.Task;
+
+            if (content.message == null)
+                throw new Exception($"\"Null\" response was received at the end of the Client Stream, message number {requestMessageNumber}, stream number: {clientStreamMessageNumber}");
+
+            if (content.message is not Response response)
+                throw new Exception($"Invalid response type {content.message.GetType().Name} was received at the end of the Client Stream, message number {requestMessageNumber}, stream number: {clientStreamMessageNumber}");
+
+            return response;
+        }
+
+        public async UniTask LaunchClientStreamAsync(Request negotiationMessage, uint portId, IUniTaskAsyncEnumerable<IMessage> stream)
+        {
+            // Server will send an ACK for the client stream
+            var streamAckPromise = new UniTaskCompletionSource<ParsedMessage>();
+            pendingMessages.TryAdd(negotiationMessage.ClientStream, streamAckPromise);
+            
+            transport.SendMessage(negotiationMessage.ToByteArray());
+
+            await streamAckPromise.Task;
+            
+            // Start the stream
+            StreamProtocol.SendStreamThroughTransportLoop(this, transport, negotiationMessage.ClientStream, portId, ProtocolHelpers.SerializeMessageEnumerator(stream)).Forget();
+        }
+
+        public (uint messageNumber, uint streamNumber) InitializeStreamNegotiation(Request negotiationMessage)
+        {
+            var clientStreamMessageNumber = NextMessageNumber();
+            var requestMessageNumber = NextMessageNumber();
+            
+            negotiationMessage.MessageIdentifier = ProtocolHelpers.CalculateMessageIdentifier(
+                RpcMessageTypes.Request,
+                requestMessageNumber
+            );
+            
+            negotiationMessage.ClientStream = clientStreamMessageNumber;
+            
+            return (requestMessageNumber, clientStreamMessageNumber);
+        }
+
+        private async UniTask<TResponse> SendAndWaitForResponse<TResponse>(IRpcMessage request, uint requestMessageNumber)
+            where TResponse : class, IMessage
+        {
+            var promise = new UniTaskCompletionSource<ParsedMessage>();
+            pendingMessages.TryAdd(requestMessageNumber, promise);
+            
+            // TODO: find an opportunity to avoid such allocation
+            var payload = request.ToByteArray();
+            
+            transport.SendMessage(payload);
+            // Failure will be resolved in `OnClose`
+            var parsedMessage = await promise.Task;
+
+            if (parsedMessage.message == null)
+                throw new Exception($"\"Null\" response was received for request {request.GetType().Name}, message number {requestMessageNumber}");
+
+            if (parsedMessage.message is not TResponse response)
+                throw new Exception($"Invalid response type {parsedMessage.message.GetType().Name} for request {request.GetType().Name}, message number {requestMessageNumber}");
+
+            return response;
+        }
+
+        internal uint NextMessageNumber()
         {
             var messageNumber = ++globalMessageNumber;
             if (globalMessageNumber > 0x01000000) globalMessageNumber = 0;

--- a/rpc-csharp/src/Runtime/StreamProtocol.cs
+++ b/rpc-csharp/src/Runtime/StreamProtocol.cs
@@ -141,9 +141,9 @@ namespace rpc_csharp
                 dispatcher.transport.OnErrorEvent -= OnTransportErrorEvent;
             }
 
-            private void OnTransportErrorEvent(string s)
+            private void OnTransportErrorEvent(Exception exception)
             {
-                channel.Close(new InvalidOperationException("RPC Transport failed"));
+                channel.Close(new InvalidOperationException("RPC Transport failed", exception));
             }
 
             private void OnTransportCloseEvent()

--- a/rpc-csharp/src/Runtime/protocol/Helpers.cs
+++ b/rpc-csharp/src/Runtime/protocol/Helpers.cs
@@ -264,7 +264,7 @@ namespace rpc_csharp.protocol
                     }
                 });
 
-                var reject = new Action<Exception>(error => { ret.TrySetException(error); });
+                var reject = new Action<Exception>(error => ret.TrySetException(error));
 
                 settlers.AddLast(new Settler(accept, reject));
                 requestingNext(this, AsyncQueueActionType.Next);

--- a/rpc-csharp/src/Runtime/protocol/IRpcMessage.cs
+++ b/rpc-csharp/src/Runtime/protocol/IRpcMessage.cs
@@ -1,0 +1,24 @@
+using Google.Protobuf;
+
+public interface IRpcMessage : IMessage
+{
+    uint MessageIdentifier { get; set; }
+}
+
+public partial class CreatePort : IRpcMessage {}
+
+public partial class CreatePortResponse : IRpcMessage {}
+
+public partial class RequestModule : IRpcMessage {}
+
+public partial class RequestModuleResponse : IRpcMessage {}
+
+public partial class DestroyPort : IRpcMessage {}
+
+public partial class Request : IRpcMessage {}
+
+public partial class RemoteError : IRpcMessage {}
+
+public partial class StreamMessage : IRpcMessage {}
+    
+    

--- a/rpc-csharp/src/Runtime/protocol/IRpcMessage.cs.meta
+++ b/rpc-csharp/src/Runtime/protocol/IRpcMessage.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e0b75faaafae467e964f003517bc9840
+timeCreated: 1747749327

--- a/rpc-csharp/src/Runtime/transport/ITransport.cs
+++ b/rpc-csharp/src/Runtime/transport/ITransport.cs
@@ -12,7 +12,7 @@ namespace rpc_csharp.transport
         // Events
         event Action OnCloseEvent;
 
-        event Action<string> OnErrorEvent;
+        event Action<Exception> OnErrorEvent;
 
         event Action<byte[]> OnMessageEvent;
 

--- a/rpc-csharp/src/Runtime/transport/MemoryTransport.cs
+++ b/rpc-csharp/src/Runtime/transport/MemoryTransport.cs
@@ -61,7 +61,7 @@ namespace rpc_csharp.transport
         }
 
         public event Action OnCloseEvent;
-        public event Action<string> OnErrorEvent;
+        public event Action<Exception> OnErrorEvent;
         public event Action<byte[]> OnMessageEvent;
         public event Action OnConnectEvent;
     }

--- a/rpc-csharp/src/package.json
+++ b/rpc-csharp/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.decentraland.rpc-csharp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "DCL RPC for Unity",
   "description": "Decentraland RPC for Unity Package",
   "unity": "2020.3",


### PR DESCRIPTION
- The original exception is not hidden and propagated to the consumer so it can react (and report) accordingly
- Error messages were improved
- The flow is streamlined to
   - Remove disconnected (Forgettable) tasks
   - Remove closures
   - Remove repetitions
   - Propagate an exception to the task properly. Before, it was based on the events that occurred on success only

There is a big room for further improvements still:
- A new memory is allocated for data on every call
- A lot of permutations of `ByteString` and `byte[]` leading to excessive allocations
- The old `ProtoBuf` version disallows using Spans
- Generation (`build.sh`) does not work on Windows